### PR TITLE
fix: run bundle analyzer only in CI build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,8 @@ import "dotenv/config";
 export default defineConfig(({ mode }) => {
   const isProduction = mode === "production";
 
+  const isCI = typeof process.env.CI !== "undefined";
+
   return {
     resolve: {
       alias: {
@@ -28,7 +30,7 @@ export default defineConfig(({ mode }) => {
         },
       }),
       codecovVitePlugin({
-        enableBundleAnalysis: isProduction,
+        enableBundleAnalysis: isProduction && isCI,
         bundleName: "@codecov/vite-plugin",
         uploadToken: process.env.CODECOV_TOKEN,
       }),


### PR DESCRIPTION
This PR contains:

- [ ] Feature
- [x] Fix
- [ ] Documentation
- [ ] Style
- [ ] Refactor
- [ ] Performance
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Chore

Are tests included?

- [ ] yes (bugfixes and features will not be merged without tests)
- [x] no

## Description

Made so bundle analyzer only runs in CI builds.
