### PR TITLE
refactor: removed forward ref

### DIFF
--- a/src/components/button/__tests__/button.tsx
+++ b/src/components/button/__tests__/button.tsx
@@ -45,6 +45,10 @@ describe("Button component", () => {
 
     render(<Button ref={refCallback}>Button</Button>);
 
+    const button = screen.getByRole("button");
+
     expect(refCallback).toHaveBeenCalledTimes(1);
+
+    expect(refCallback).toHaveBeenCalledWith(button);
   });
 });

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,10 +1,5 @@
-import { forwardRef } from "react";
 import type { ComponentProps } from "react";
 
-export const Button = forwardRef<HTMLButtonElement, ComponentProps<"button">>(
-  (props, ref) => {
-    return <button ref={ref} {...props} />;
-  },
-);
-
-Button.displayName = "Button";
+export const Button = (props: ComponentProps<"button">) => {
+  return <button {...props} />;
+};


### PR DESCRIPTION
This PR contains:

- [ ] Feature
- [ ] Fix
- [ ] Documentation
- [ ] Style
- [x] Refactor
- [ ] Performance
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Chore

Are tests included?

- [x] yes (bugfixes and features will not be merged without tests)
- [ ] no

## Description

Removed `forwardRef` from Button component since in React 19.0 it's no longer needed.
